### PR TITLE
make test badges more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Heavily inspired by [devtodo][devtodo], but with some nasty features, like:
 * Sorting/Filtering specific levels only.
 * Persistent sort/filter/view options.
 * Written in pure Python (it even has docstrings).
-* Tests ([![Build Status](https://travis-ci.org/KenjiTakahashi/td.png?branch=master)](https://travis-ci.org/KenjiTakahashi/td)[![Coverage](https://coveralls.io/repos/KenjiTakahashi/td/badge.png?branch=master)](https://coveralls.io/r/KenjiTakahashi/td)).
+* Tests ([![Build Status](https://travis-ci.org/KenjiTakahashi/td.png?branch=master)](https://travis-ci.org/KenjiTakahashi/td) [![Coverage](https://coveralls.io/repos/KenjiTakahashi/td/badge.png?branch=master)](https://coveralls.io/r/KenjiTakahashi/td)).
 
 Oh, and it will automagically pick up your existing [devtodo][devtodo] lists!
 


### PR DESCRIPTION
Add a space between build status and coverage percent badges so you can tell that they are two separate badges, not one big multi-segmented badge.
